### PR TITLE
Finish implementing method lookups using dictionaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,10 @@ target_include_directories(ovm-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(ovm-lib-strict PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(ovm main.c)
+add_executable(ovm-strict main.c)
+
 target_link_libraries(ovm ovm-lib)
+target_link_libraries(ovm-strict ovm-lib-strict)
 
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 

--- a/src/ovm/odictionary.h
+++ b/src/ovm/odictionary.h
@@ -7,18 +7,17 @@
 
 typedef union ODICTIONARY_VALUE_T {
   OVM_UINT uint_val;
+  OVM_PTR ovm_ptr_val;
   void *ptr_val;
 } ODICTIONARY_VALUE;
 
-typedef struct ODICTIONARY_ENTRY_T
-{
+typedef struct ODICTIONARY_ENTRY_T {
   ODICTIONARY_VALUE key;
   ODICTIONARY_VALUE value;
   bool is_used;
 } ODICTIONARY_ENTRY;
 
-typedef struct ODICTIONARY_T
-{
+typedef struct ODICTIONARY_T {
   ODICTIONARY_ENTRY *records;
   uint8_t num_entries;
   uint8_t max_entries;

--- a/src/ovm/oexecutor.c
+++ b/src/ovm/oexecutor.c
@@ -2,8 +2,8 @@
 #include "obytecode.h"
 #include "ovm.h"
 
-void oexecutor_init_all() {
-  EXECUTORS[OP_INVOKE] = oexecutor_invoke;
+void oexecutor_init_all()
+{
   EXECUTORS[OP_INVOKE_STATIC] = oexecutor_invoke_static;
   EXECUTORS[OP_INVOKE_VIRTUAL] = oexecutor_invoke_virtual;
   EXECUTORS[OP_RETURN] = oexecutor_return;
@@ -18,7 +18,8 @@ void oexecutor_init_all() {
   EXECUTORS[OP_DUP] = oexecutor_dup;
 }
 
-void oexecutor_return(OSTATE *ovm) {
+void oexecutor_return(OSTATE *ovm)
+{
   OSTACK_OBJECT return_val = ostack_pop(&ovm->stack);
 
   ovm_return(ovm);
@@ -30,32 +31,8 @@ void oexecutor_return_void(OSTATE *ovm) { ovm_return(ovm); }
 
 void oexecutor_halt(OSTATE *ovm) { ovm_exit(ovm, 0); }
 
-void oexecutor_invoke(OSTATE *ovm) {
-  OVM_UINT obj_id = obytecode_read_uint(ovm);
-#ifdef VM_STRICT_MODE
-  if (obj_id >= ovm->num_objects) {
-    ovm_throw(ovm, "Invoked method on object id out of range.");
-  }
-#endif
-
-  OVM_UINT method_id = obytecode_read_uint(ovm);
-  OVM_UINT num_args = obytecode_read_uint(ovm);
-
-  OVM_PTR bytecode_ptr =
-      oobject_resolve_method(&ovm->objects[obj_id], method_id);
-
-#ifdef VM_STRICT_MODE
-  if (bytecode_ptr == OVM_NULL) {
-    ovm_throw(ovm, "Invoked non-existing method.");
-  }
-#endif
-
-  OVM_PTR obj_ref = ostack_top(&ovm->stack, num_args + 1).ptr_val;
-
-  ovm_call(ovm, bytecode_ptr, num_args, obj_ref);
-}
-
-void oexecutor_invoke_virtual(OSTATE *ovm) {
+void oexecutor_invoke_virtual(OSTATE *ovm)
+{
   OVM_UINT interface_id = obytecode_read_uint(ovm);
   OVM_UINT method_id = obytecode_read_uint(ovm);
   OVM_UINT num_args = obytecode_read_uint(ovm);
@@ -66,17 +43,26 @@ void oexecutor_invoke_virtual(OSTATE *ovm) {
   OVM_PTR bytecode_ptr =
       oobject_virtual_resolve_method(obj, interface_id, method_id);
 
+#ifdef VM_STRICT_MODE
+  if (bytecode_ptr == OVM_NULL)
+  {
+    ovm_throw(ovm, "Failed to resolve virtual method. Verify that interface id and method id is correct.");
+  }
+#endif
+
   ovm_call(ovm, bytecode_ptr, num_args, obj_ref);
 }
 
-void oexecutor_invoke_static(OSTATE *ovm) {
+void oexecutor_invoke_static(OSTATE *ovm)
+{
   OVM_PTR bytecode_ptr = obytecode_read_uint(ovm);
   OVM_PTR num_args = obytecode_read_uint(ovm);
 
   ovm_call_static(ovm, bytecode_ptr, num_args);
 }
 
-void oexecutor_local_load(OSTATE *ovm) {
+void oexecutor_local_load(OSTATE *ovm)
+{
   OVM_UINT offset = obytecode_read_uint(ovm);
 
   OSTACK_OBJECT local = ostack_at(&ovm->stack, ovm->frame_ptr - offset);
@@ -84,7 +70,8 @@ void oexecutor_local_load(OSTATE *ovm) {
   ostack_push(&ovm->stack, local);
 }
 
-void oexecutor_new(OSTATE *ovm) {
+void oexecutor_new(OSTATE *ovm)
+{
   OVM_UINT obj_id = obytecode_read_uint(ovm);
   OOBJECT obj = ovm->objects[obj_id];
 
@@ -95,7 +82,8 @@ void oexecutor_new(OSTATE *ovm) {
   ostack_push(&ovm->stack, ostack_obj_of_ptr(obj_ref));
 }
 
-void oexecutor_dup(OSTATE *ovm) {
+void oexecutor_dup(OSTATE *ovm)
+{
   OSTACK_OBJECT so = ostack_top(&ovm->stack, 1);
 
   ostack_push(&ovm->stack, so);

--- a/src/ovm/oexecutor.h
+++ b/src/ovm/oexecutor.h
@@ -17,8 +17,6 @@ void oexecutor_return_void(OSTATE *ovm);
 
 void oexecutor_halt(OSTATE *ovm);
 
-void oexecutor_invoke(OSTATE *ovm);
-
 void oexecutor_invoke_virtual(OSTATE *ovm);
 
 void oexecutor_invoke_static(OSTATE *ovm);

--- a/src/ovm/oobject.c
+++ b/src/ovm/oobject.c
@@ -1,60 +1,72 @@
 #include "oobject.h"
 #include <stdlib.h>
 
-OVM_PTR oobject_resolve_method(OOBJECT *o, OVM_UINT method_id) {
-#ifdef VM_STRICT_MODE
-  if (method_id >= o->funcs.num_funcs) {
-    return OVM_NULL;
-  }
-#endif
-
-  return o->funcs.func_ptrs[method_id];
-}
-
-OVM_PTR oobject_base_resolve_method(OOBJECT *o, OVM_UINT method_id) {
-#ifdef VM_STRICT_MODE
-  if (o->base == NULL) {
-    return OVM_NULL;
-  }
-#endif
-
-  return oobject_resolve_method(o->base, method_id);
-}
-
 OVM_PTR oobject_virtual_resolve_method(OOBJECT *o, OVM_UINT vinterface_id,
-                                       OVM_UINT method_id) {
-  ODICTIONARY_VALUE key = {.uint_val = vinterface_id};
-  ODICTIONARY_ENTRY *entry_found = odictionary_lookup(&o->vfuncs, key);
+                                       OVM_UINT method_id)
+{
+  ODICTIONARY_VALUE interface_key = {.uint_val = vinterface_id};
+  ODICTIONARY_ENTRY *interface_found =
+      odictionary_lookup(&o->vfuncs, interface_key);
 
 #ifdef VM_STRICT_MODE
-  if (entry_found == NULL) {
+  if (interface_found == NULL)
+  {
     return OVM_NULL;
   }
 #endif
 
-  OOBJECT_FUNC_TABLE *vfunc_table_for_interface =
-      (OOBJECT_FUNC_TABLE *)entry_found->value.ptr_val;
+  OOBJECT_FUNC_TABLE *func_table =
+      (OOBJECT_FUNC_TABLE *)interface_found->value.ptr_val;
+
+  ODICTIONARY_VALUE method_key = {.uint_val = method_id};
+  ODICTIONARY_ENTRY *method_found =
+      odictionary_lookup(&func_table->func_ptrs, method_key);
+
 #ifdef VM_STRICT_MODE
-  if (method_id >= vfunc_table_for_interface->num_funcs) {
+  if (method_found == NULL)
+  {
     return OVM_NULL;
   }
 #endif
-  return vfunc_table_for_interface->func_ptrs[method_id];
+
+  return method_found->value.ovm_ptr_val;
 }
 
-void oobject_data_init(OOBJECT *o, void *obj_ptr) {
+void oobject_register_interface(OOBJECT *o, OVM_UINT interface_id,
+                                OOBJECT_FUNC_TABLE *func_table)
+{
+  ODICTIONARY_VALUE key = {.uint_val = interface_id};
+  ODICTIONARY_VALUE value = {.ptr_val = func_table};
+
+  odictionary_set(&o->vfuncs, key,
+                  value); // TODO add check in strict mode to see if set worked
+}
+
+void oobject_data_init(OOBJECT *o, void *obj_ptr)
+{
   OOBJECT_DATA_HEADER *header = (OOBJECT_DATA_HEADER *)obj_ptr;
   header->obj_id = o->obj_id;
 }
 
-char *oobject_data_start(void *obj_ptr) {
+char *oobject_data_start(void *obj_ptr)
+{
   return (char *)obj_ptr + sizeof(OOBJECT_DATA_HEADER);
 }
 
-OVM_UINT oobject_data_get_id(void *obj_ptr) {
+OVM_UINT oobject_data_get_id(void *obj_ptr)
+{
   OOBJECT_DATA_HEADER *header = (OOBJECT_DATA_HEADER *)obj_ptr;
 
   return header->obj_id;
 }
 
 void oobject_free(OOBJECT *o) { odictionary_free(&o->vfuncs); }
+
+void ofunc_table_register_method(OOBJECT_FUNC_TABLE *func_table,
+                                 OVM_UINT method_id, OVM_PTR method_ptr)
+{
+  ODICTIONARY_VALUE method_key = {.uint_val = method_id};
+  ODICTIONARY_VALUE value = {.ovm_ptr_val = method_ptr};
+
+  odictionary_set(&func_table->func_ptrs, method_key, value);
+}

--- a/src/ovm/oobject.h
+++ b/src/ovm/oobject.h
@@ -5,27 +5,29 @@
 #include "otypes.h"
 #include <stdint.h>
 
-typedef struct OOBJECT_FUNC_TABLE_T {
-  OVM_PTR *func_ptrs;
-  uint8_t num_funcs;
+typedef struct OOBJECT_FUNC_TABLE_T
+{
+  ODICTIONARY func_ptrs;
 } OOBJECT_FUNC_TABLE;
 
-typedef struct OOBJECT_T {
+typedef struct OOBJECT_T
+{
   OVM_UINT obj_id;
-  OOBJECT_FUNC_TABLE funcs;
   ODICTIONARY vfuncs;
   struct OBMOBJECT_T *base;
   uint64_t mem_size;
 } OOBJECT;
 
-typedef struct OOBJECT_DATA_HEADER_T { OVM_UINT obj_id; } OOBJECT_DATA_HEADER;
-
-OVM_PTR oobject_resolve_method(OOBJECT *o, OVM_UINT method_id);
-
-OVM_PTR oobject_base_resolve_method(OOBJECT *o, OVM_UINT method_id);
+typedef struct OOBJECT_DATA_HEADER_T
+{
+  OVM_UINT obj_id;
+} OOBJECT_DATA_HEADER;
 
 OVM_PTR oobject_virtual_resolve_method(OOBJECT *o, OVM_UINT vinterface_id,
                                        OVM_UINT method_id);
+
+void oobject_register_interface(OOBJECT *o, OVM_UINT interface_id,
+                                OOBJECT_FUNC_TABLE *func_table);
 
 void oobject_data_init(OOBJECT *o, void *obj_ptr);
 
@@ -34,5 +36,7 @@ char *oobject_data_start(void *obj_ptr);
 OVM_UINT oobject_data_get_id(void *obj_ptr);
 
 void oobject_free(OOBJECT *o);
+
+void ofunc_table_register_method(OOBJECT_FUNC_TABLE *func_table, OVM_UINT method_id, OVM_PTR method_ptr);
 
 #endif /* OOBJECT_H */

--- a/src/ovm/oops.h
+++ b/src/ovm/oops.h
@@ -1,10 +1,10 @@
 #ifndef OOPS_H
 #define OOPS_H
 
-enum OVM_OP {
+enum OVM_OP
+{
   OP_HALT,
   OP_NEW,
-  OP_INVOKE,
   OP_INVOKE_STATIC,
   OP_INVOKE_VIRTUAL,
   OP_RETURN_VOID,

--- a/src/ovm/ovm.c
+++ b/src/ovm/ovm.c
@@ -8,8 +8,7 @@
 void ovm_init() { oexecutor_init_all(); }
 
 OSTATE ovm_create(uint16_t stack_size, char *bytecode, uint64_t bytecode_length,
-                  uint64_t initial_heap_size)
-{
+                  uint64_t initial_heap_size) {
   OSTATE ovm;
   ovm.num_objects = 0;
   ovm.objects = NULL;
@@ -18,46 +17,40 @@ OSTATE ovm_create(uint16_t stack_size, char *bytecode, uint64_t bytecode_length,
 
   ovm.bytecode = bytecode;
   ovm.bytecode_length = bytecode_length;
-  ovm.bytecode_ptr = 0;
+  ovm.bytecode_ptr = 1; // 0 is reserved for OVM_NULL
 
   ovm.memory = omemory_create(initial_heap_size);
 
   return ovm;
 }
 
-void ovm_free(OSTATE *ovm)
-{
+void ovm_free(OSTATE *ovm) {
   ostack_free(&ovm->stack);
   omemory_free(&ovm->memory);
 }
 
-void ovm_run(OSTATE *ovm)
-{
-  for (;;)
-  {
+void ovm_run(OSTATE *ovm) {
+  for (;;) {
     OVM_OP op = obytecode_read_op(ovm);
 
     EXECUTORS[op](ovm);
   }
 }
 
-void ovm_load_object(OSTATE *ovm, OOBJECT o)
-{
+void ovm_load_object(OSTATE *ovm, OOBJECT o) {
   ovm->num_objects++;
   ovm->objects = realloc(ovm->objects, sizeof(OOBJECT) * ovm->num_objects);
   ovm->objects[ovm->num_objects - 1] = o;
 }
 
-void ovm_throw(OSTATE *ovm, char *err)
-{
+void ovm_throw(OSTATE *ovm, char *err) {
   printf("Exception encountered: %s\n", err);
 
   exit(1);
 }
 
 void ovm_call(OSTATE *ovm, OVM_PTR bytecode_ptr, OVM_UINT num_args,
-              OVM_PTR obj_ref)
-{
+              OVM_PTR obj_ref) {
   ostack_push(&ovm->stack, ostack_obj_of_ptr(obj_ref));
 
   ovm_call_static(ovm, bytecode_ptr,
@@ -66,8 +59,7 @@ void ovm_call(OSTATE *ovm, OVM_PTR bytecode_ptr, OVM_UINT num_args,
                                  // argument
 }
 
-void ovm_call_static(OSTATE *ovm, OVM_PTR bytecode_ptr, OVM_UINT num_args)
-{
+void ovm_call_static(OSTATE *ovm, OVM_PTR bytecode_ptr, OVM_UINT num_args) {
   OVM_PTR return_ptr = ovm->bytecode_ptr;
   OVM_PTR frame_ptr = ovm->frame_ptr;
 
@@ -79,8 +71,7 @@ void ovm_call_static(OSTATE *ovm, OVM_PTR bytecode_ptr, OVM_UINT num_args)
   ostack_push(&ovm->stack, ostack_obj_of_ptr(frame_ptr));
 }
 
-void ovm_return(OSTATE *ovm)
-{
+void ovm_return(OSTATE *ovm) {
   ostack_to_index(&ovm->stack, ovm->frame_ptr + 3);
 
   ovm->frame_ptr = ostack_pop(&ovm->stack).ptr_val;
@@ -88,21 +79,18 @@ void ovm_return(OSTATE *ovm)
 
   OVM_UINT num_args = ostack_pop(&ovm->stack).uint_val;
 
-  for (int i = 0; i < num_args; i++)
-  {
+  for (int i = 0; i < num_args; i++) {
     ostack_pop(&ovm->stack);
   }
 }
 
-void ovm_exit(OSTATE *ovm, OVM_UINT exit_code)
-{
+void ovm_exit(OSTATE *ovm, OVM_UINT exit_code) {
   printf("OVM halted with exit code %u.\n", exit_code);
 
   exit(exit_code);
 }
 
-OOBJECT *ovm_object_at(OSTATE *ovm, OVM_PTR obj_ptr)
-{
+OOBJECT *ovm_object_at(OSTATE *ovm, OVM_PTR obj_ptr) {
   void *obj_data_ptr = omemory_at(&ovm->memory, obj_ptr);
   OVM_UINT obj_id = oobject_data_get_id(obj_data_ptr);
 

--- a/test/test_oobject.c
+++ b/test/test_oobject.c
@@ -1,54 +1,16 @@
 #include <ovm/oobject.h>
 #include <unity.h>
 
-OOBJECT gen_oobject_with(OOBJECT_FUNC_TABLE func_table)
-{
-  OOBJECT o;
-  o.funcs = func_table;
-
-  return o;
-}
-
 OOBJECT_FUNC_TABLE gen_oobject_func_table(OVM_PTR *table, uint8_t size)
 {
-  OOBJECT_FUNC_TABLE func_table;
-  func_table.func_ptrs = table;
-  func_table.num_funcs = size;
+  OOBJECT_FUNC_TABLE func_table = {.func_ptrs = odictionary_create(size)};
+
+  for (int i = 0; i < size; i++)
+  {
+    ofunc_table_register_method(&func_table, i, table[i]);
+  }
 
   return func_table;
-}
-
-void oobject_register_interface(OOBJECT *o, OVM_UINT interface_id,
-                                OOBJECT_FUNC_TABLE *t)
-{
-  ODICTIONARY_VALUE key = {.uint_val = interface_id};
-  ODICTIONARY_VALUE value = {.ptr_val = t};
-
-  odictionary_set(&o->vfuncs, key, value);
-}
-
-void test_oobject_should_resolve_existing_method()
-{
-  OVM_PTR func_ptrs[] = {10, 30};
-  OOBJECT_FUNC_TABLE func_table = gen_oobject_func_table(&func_ptrs, 2);
-  OOBJECT o = gen_oobject_with(func_table);
-
-  OVM_PTR resolved_ptr = oobject_resolve_method(&o, 1);
-
-  TEST_ASSERT_EQUAL_INT(30, resolved_ptr);
-}
-
-void test_oobject_should_resolve_base_method()
-{
-  OVM_PTR child_func_ptrs[] = {34};
-  OVM_PTR base_func_ptrs[] = {27, 10};
-  OOBJECT child = gen_oobject_with(gen_oobject_func_table(&child_func_ptrs, 1));
-  OOBJECT base = gen_oobject_with(gen_oobject_func_table(&base_func_ptrs, 2));
-  child.base = &base;
-
-  OVM_PTR resolved_ptr = oobject_base_resolve_method(&child, 0);
-
-  TEST_ASSERT_EQUAL_INT(27, resolved_ptr);
 }
 
 void test_oobject_should_resolve_virtual_method()
@@ -68,26 +30,8 @@ void test_oobject_should_resolve_virtual_method()
   TEST_ASSERT_EQUAL_INT(30, resolved_ptr);
 
   odictionary_free(&o.vfuncs);
-}
-
-void test_strict_oobject_resolve_should_return_null_given_non_existing_method()
-{
-  OOBJECT_FUNC_TABLE func_table = gen_oobject_func_table(NULL, 0);
-  OOBJECT o = gen_oobject_with(func_table);
-
-  OVM_PTR resolved_ptr = oobject_resolve_method(&o, 12);
-
-  TEST_ASSERT_EQUAL_INT(OVM_NULL, resolved_ptr);
-}
-
-void test_strict_oobject_should_resolve_base_return_null_given_no_base_object()
-{
-  OOBJECT o;
-  o.base = NULL;
-
-  OVM_PTR resolved_ptr = oobject_base_resolve_method(&o, 0);
-
-  TEST_ASSERT_EQUAL_INT(OVM_NULL, resolved_ptr);
+  odictionary_free(&vfunc_table1.func_ptrs);
+  odictionary_free(&vfunc_table2.func_ptrs);
 }
 
 void test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_interface()
@@ -104,8 +48,8 @@ void test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_i
 
 void test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_method()
 {
-  OVM_PTR vfunc_ptrs1[] = {1, 2, 3, 4};
-  OOBJECT_FUNC_TABLE vfunc_table = gen_oobject_func_table(&vfunc_ptrs1, 4);
+  OVM_PTR vfunc_ptrs[] = {1, 2, 3, 4};
+  OOBJECT_FUNC_TABLE vfunc_table = gen_oobject_func_table(&vfunc_ptrs, 4);
   OOBJECT o;
   o.vfuncs = odictionary_create(1);
   oobject_register_interface(&o, 10, &vfunc_table);
@@ -115,25 +59,20 @@ void test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_m
   TEST_ASSERT_EQUAL_INT(OVM_NULL, resolved_ptr);
 
   odictionary_free(&o.vfuncs);
+  odictionary_free(&vfunc_table.func_ptrs);
 }
 
 int main(void)
 {
   UNITY_BEGIN();
 
-  RUN_TEST(test_oobject_should_resolve_existing_method);
-  RUN_TEST(test_oobject_should_resolve_base_method);
   RUN_TEST(test_oobject_should_resolve_virtual_method);
 
 #ifdef VM_STRICT_MODE
   RUN_TEST(
-      test_strict_oobject_resolve_should_return_null_given_non_existing_method);
+      test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_interface);
   RUN_TEST(
-      test_strict_oobject_should_resolve_base_return_null_given_no_base_object);
-  // RUN_TEST(
-//     test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_interface);
-// RUN_TEST(
-//     test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_method);
+      test_strict_oobject_resolve_virtual_should_return_null_given_non_existing_method);
 #endif
 
   return UNITY_END();


### PR DESCRIPTION
At last! The VM is now truly capable of implementing object-oriented concepts such as inheritance, method overriding, method implementation, etc. This branch makes it so that all of the object's methods are virtual, meaning that they always have to be called as if you were interacting with an interface. Basically, here is how it works:

We have an object struct which in pseudocode contains:
```c#
struct Object {
  Map<UInt, FuncTable> interfaces;
}
```
Where UInt is the interface ID.

An object can implement as many interfaces as needed. Note that the object also implements it's own methods like an interface, so in reality interface ID can also be object ID.

The func table struct also contains:
```C#
struct FuncTable {
  Map<UInt, Ptr> func_ptrs;
}
```
Where UInt is the method ID, and Ptr points to where the instruction pointer should go.
 
So suppose that I want to call a method of an object whose interface ID is 0, and who has a method with ID 3:
`OP_INVOKE_VIRTUAL, 0, 3;`

Then, the lookup looks like this:
`instruction_ptr = interfaces[interface_id].func_ptrs[method_id].ptr;`

I've also made sure that the VM throws an error in strict mode if it could not resolve the method, in the case that the programmer typed a non-existant interface ID, or a non-existant method ID for that object.